### PR TITLE
Remove async for better user experience

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -46,14 +47,14 @@ class _BooksAppState extends State<BooksApp> with RestorationMixin {
 class BookRouteInformationParser extends RouteInformationParser<BookRoutePath> {
   @override
   Future<BookRoutePath> parseRouteInformation(
-      RouteInformation routeInformation) async {
+      RouteInformation routeInformation) {
     final uri = Uri.parse(routeInformation.location!);
 
     if (uri.pathSegments.length >= 2) {
       var remaining = uri.pathSegments[1];
-      return BookRoutePath.details(int.tryParse(remaining)!);
+      return SynchronousFuture(BookRoutePath.details(int.tryParse(remaining)!));
     } else {
-      return BookRoutePath.home();
+      return SynchronousFuture(BookRoutePath.home());
     }
   }
 
@@ -125,10 +126,11 @@ class BookRouterDelegate extends RouterDelegate<BookRoutePath>
   }
 
   @override
-  Future<void> setNewRoutePath(BookRoutePath path) async {
+  Future<void> setNewRoutePath(BookRoutePath path) {
     if (path.isDetailsPage) {
       _selectedBook = books[path.id!];
     }
+    return SynchronousFuture<void>(null);
   }
 
   void _handleBookTapped(Book book) {


### PR DESCRIPTION
Some methods of the Router API support asynchronous processing. However, if the information is available synchronously, it's best to just return a SynchronousFuture to indicate that (also documented, e.g. here: https://master-api.flutter.dev/flutter/widgets/RouterDelegate/setNewRoutePath.html). 

What's the difference? Let's say we link directly to `/book/1`. When `parseRouteInformation` is async, the Router will render for one frame the home page `/` because the Future returned by `parseRouteInformation` with the correct route information will not complete until the next frame. When the future then complete in the next frame, `/book/1` is rendered as expected.

When `parseRouteInformation` returns a SynchronousFuture, the information that `/book/1` should be rendered is available in the first frame and the Router can render `/book/1` correctly even for the first frame.